### PR TITLE
Set encoding explicitly

### DIFF
--- a/CSharp/CSharpPilot2/CSharpPilot2/Locales/Locale.cs
+++ b/CSharp/CSharpPilot2/CSharpPilot2/Locales/Locale.cs
@@ -1,7 +1,12 @@
-﻿namespace CSharpPilot2.Locales
+﻿using System.Text;
+
+namespace CSharpPilot2.Locales
 {
     internal abstract class Locale
     {
+        public virtual Encoding GetEncoding() =>
+            Encoding.UTF8;
+
         public abstract string GetNameRequestString(int playerIndex);
         public abstract string GetWordRequestString(string playerName);
         public abstract string GetInvalidWordString(string word);

--- a/CSharp/CSharpPilot2/CSharpPilot2/Program.cs
+++ b/CSharp/CSharpPilot2/CSharpPilot2/Program.cs
@@ -4,6 +4,8 @@ using System.Linq;
 
 using CSharpPilot2.Gameplay;
 using CSharpPilot2.Input;
+using System.Text;
+
 using CSharpPilot2.Locales;
 
 namespace CSharpPilot2
@@ -12,7 +14,13 @@ namespace CSharpPilot2
     {
         private static void Main(string[] args)
         {
-            Game game = new(ReadInputInfo, GetRules(), new RussianLocale());
+            Locale locale = new RussianLocale();
+
+            Encoding encoding = locale.GetEncoding();
+            Console.InputEncoding = encoding;
+            Console.OutputEncoding = encoding;
+
+            Game game = new(ReadInputInfo, GetRules(), locale);
             game.Start();
         }
 


### PR DESCRIPTION
Now all locales have their own encodings. The game will use the locale's encoding for console input and output. The encoding used by default is UTF8.